### PR TITLE
build(android): target API level 35

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -107,13 +107,13 @@ android {
     ndkVersion rootProject.ext.ndkVersion
 
     buildToolsVersion rootProject.ext.buildToolsVersion
-    compileSdk rootProject.ext.compileSdkVersion
+    compileSdk 35
 
     namespace 'com.ruvia.app'
     defaultConfig {
         applicationId 'com.ruvia.app'
         minSdkVersion rootProject.ext.minSdkVersion
-        targetSdkVersion rootProject.ext.targetSdkVersion
+        targetSdkVersion 35
         versionCode 1
         versionName "0.1.0"
         // Resolve variant ambiguity for react-native-iap flavors (amazon/play)

--- a/app.json
+++ b/app.json
@@ -17,6 +17,8 @@
         "expo-build-properties",
         {
           "android": {
+            "compileSdkVersion": 35,
+            "targetSdkVersion": 35,
             "extraGradleProperties": {
               "REACT_NATIVE_IAP_STORE": "play"
             }


### PR DESCRIPTION
## Summary
- configure `expo-build-properties` to use Android API level 35
- set Gradle compile and target SDK versions to 35

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7ca764868832a9fa474620fb4cd47