### PR TITLE
Fix UI glitches, auth persistence and splash screen

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,8 +92,8 @@ android {
         applicationId 'com.ruvia.app'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 29
-        versionName "0.1.27"
+        versionCode 30
+        versionName "0.1.28"
     }
     signingConfigs {
         debug {

--- a/app.json
+++ b/app.json
@@ -3,7 +3,7 @@
     "name": "Ruvia",
     "slug": "ruvia",
     "scheme": "ruvia",
-    "version": "0.1.27",
+    "version": "0.1.28",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "dark",
@@ -38,6 +38,11 @@
       "expo-font",
       "expo-web-browser"
     ],
+    "splash": {
+      "image": "./assets/icon.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#000000"
+    },
     "android": {
       "package": "com.ruvia.app",
       "permissions": [
@@ -51,7 +56,7 @@
         "backgroundColor": "#000000",
         "monochromeImage": "./assets/adaptive-icon-monochrome.png"
       },
-      "versionCode": 29,
+      "versionCode": 30,
       "googleServicesFile": "./google-services.json"
     },
     "extra": {

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -7,7 +7,7 @@ export default function TabsLayout() {
     <Tabs
       screenOptions={{
         headerShown: false,
-        tabBarStyle: { backgroundColor: "#000", borderTopWidth: 0, paddingTop: 10, paddingBottom: 10, height: 62 },
+        tabBarStyle: { backgroundColor: "#000", borderTopWidth: 0, paddingTop: 10, paddingBottom: 10, height: 72 },
         tabBarActiveTintColor: colors.PRIMARY,
         tabBarInactiveTintColor: "#999",
         tabBarItemStyle: { paddingTop: 4, paddingBottom: 2 },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ruvia",
-  "version": "0.1.27",
+  "version": "0.1.28",
   "private": true,
   "main": "index.js",
   "scripts": {

--- a/src/__tests__/logoTitle.test.tsx
+++ b/src/__tests__/logoTitle.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { View } from 'react-native';
+import renderer from 'react-test-renderer';
+import LogoTitle from '@/components/LogoTitle';
+
+describe('LogoTitle', () => {
+  it('uses compact gap between icon and text', () => {
+    const tree = renderer.create(<LogoTitle />).root;
+    const view = tree.findByType(View);
+    const style = Array.isArray(view.props.style) ? view.props.style.find(s => s && 'gap' in s) : view.props.style;
+    expect(style.gap).toBe(4);
+  });
+});

--- a/src/__tests__/settings.test.tsx
+++ b/src/__tests__/settings.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import Settings from '@/screens/Settings';
+
+const mockLogout = jest.fn().mockResolvedValue(undefined);
+const mockReplace = jest.fn();
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ logout: mockLogout, user: { displayName: 'Test', email: 'test@example.com' } })
+}));
+
+jest.mock('expo-router', () => ({
+  useRouter: () => ({ replace: mockReplace, push: jest.fn() })
+}));
+
+describe('Settings logout', () => {
+  it('redirects to sign up page on logout', async () => {
+    const { getByText } = render(<Settings />);
+    await act(async () => {
+      fireEvent.press(getByText('Log out'));
+    });
+    expect(mockReplace).toHaveBeenCalledWith('/');
+    expect(mockLogout).toHaveBeenCalled();
+  });
+});

--- a/src/components/LogoTitle.tsx
+++ b/src/components/LogoTitle.tsx
@@ -4,7 +4,7 @@ import * as colors from '@/theme/theme';
 export default function LogoTitle({ title = 'Ruvia' }: { title?: string }) {
   const text = typeof title === 'string' && title.length > 0 ? title.slice(1) : title;
   return (
-    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 8 }}>
+    <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4 }}>
       <Image source={require('../../assets/icon.png')} style={{ width: 20, height: 20, borderRadius: 4 }} />
       <Text accessibilityRole="header" style={{ color: colors.TEXT, fontSize: 20, fontWeight: '700' }}>{text}</Text>
     </View>

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,6 +1,7 @@
 import { initializeApp, getApps } from 'firebase/app';
-import { getAuth, GoogleAuthProvider } from 'firebase/auth';
+import { initializeAuth, getReactNativePersistence, GoogleAuthProvider } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const firebaseConfig = {
   apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
@@ -14,6 +15,8 @@ const firebaseConfig = {
 // Avoid initializing Firebase during static SSR/Expo export on the server.
 const isBrowser = typeof window !== 'undefined';
 const app = isBrowser && (getApps().length ? getApps()[0]! : initializeApp(firebaseConfig));
-export const auth = isBrowser ? getAuth(app as any) : (null as any);
+export const auth = isBrowser
+  ? initializeAuth(app as any, { persistence: getReactNativePersistence(AsyncStorage) })
+  : (null as any);
 export const db = isBrowser ? getFirestore(app as any) : (null as any);
 export const googleProvider = isBrowser ? new GoogleAuthProvider() : (null as any);

--- a/src/screens/Purchase.tsx
+++ b/src/screens/Purchase.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from 'react';
 // Loaded dynamically on Android to avoid web build issues
 // import * as InAppPurchases from 'expo-in-app-purchases';
 import { useAuth } from '@/hooks/useAuth';
+import PrimaryButton from '@/components/ui/PrimaryButton';
 
 type Plan = { sku: string; title: string; price: string; credits: number; save?: string };
 const STATIC_PLANS: Plan[] = [

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -17,7 +17,16 @@ export default function Settings() {
       <Pressable onPress={() => router.push('/privacy')} style={{ backgroundColor: '#111', padding: 14, borderRadius: 12, borderColor: '#222', borderWidth: 1 }}>
         <Text style={{ color: '#fff' }}>Privacy Policy</Text>
       </Pressable>
-      <Pressable onPress={async () => { await logout(); router.replace('/'); }} style={{ backgroundColor: '#111', padding: 14, borderRadius: 12, borderColor: '#222', borderWidth: 1, marginTop: 16 }}>
+      <Pressable
+        onPress={async () => {
+          try {
+            await logout();
+          } finally {
+            router.replace('/');
+          }
+        }}
+        style={{ backgroundColor: '#111', padding: 14, borderRadius: 12, borderColor: '#222', borderWidth: 1, marginTop: 16 }}
+      >
         <Text style={{ color: '#fff' }}>Log out</Text>
       </Pressable>
       <Pressable onPress={() => Alert.alert('Delete account', 'Please contact support to delete your account.')} style={{ backgroundColor: '#111', padding: 14, borderRadius: 12, borderColor: '#222', borderWidth: 1 }}>


### PR DESCRIPTION
## Summary
- ensure bottom tab bar shows labels
- keep users signed in between app launches
- fix missing PrimaryButton on purchase screen and redirect to sign up after logout
- tighten logo spacing and use custom splash screen
- bump version and add unit tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c33c616aa0832a8a2064fb3cdc8352